### PR TITLE
Fix type of first argument of initMyTable

### DIFF
--- a/ModelicaCompliance/Resources/Include/ExtObj.c
+++ b/ModelicaCompliance/Resources/Include/ExtObj.c
@@ -9,7 +9,7 @@
 #include "ExtObj.h"
 
 /* Constructor for MyTable. */
-void* initMyTable(const double *table_data, size_t table_size)
+void* initMyTable(double *table_data, size_t table_size)
 {
   MyTable *table = (MyTable*)malloc(sizeof(MyTable));
 

--- a/ModelicaCompliance/Resources/Include/ExtObj.h
+++ b/ModelicaCompliance/Resources/Include/ExtObj.h
@@ -6,7 +6,7 @@ typedef struct {
   unsigned size;
 } MyTable;
 
-void* initMyTable(const double *table_data, size_t table_size);
+void* initMyTable(double *table_data, size_t table_size);
 void closeMyTable(void* object);
 double interpolateMyTable(void* object, double u);
 


### PR DESCRIPTION
According to MLS 3.3r1 section 12.9.1.2 the argument type of `Real[:]` is `double *`.