### PR TITLE
Fix ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid

### DIFF
--- a/ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid.mo
+++ b/ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid.mo
@@ -6,8 +6,8 @@ model BoolArrayInvalid
   type B = Boolean;
   Real arr1[B];
 equation
-  arr[1] = true;
-  arr[2] = false;
+  arr[1] = 0.0;
+  arr[2] = 1.0;
 
   annotation (
     __ModelicaAssociation(TestCase(shouldPass = false, section = {"4.8.3", "10.1.1", "10.5.1"})),

--- a/ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid.mo
+++ b/ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid.mo
@@ -4,7 +4,7 @@ model BoolArrayInvalid
   extends Icons.TestCase;
 
   type B = Boolean;
-  Real arr1[B];
+  Real arr[B];
 equation
   arr[1] = 0.0;
   arr[2] = 1.0;


### PR DESCRIPTION
Currently the test ModelicaCompliance/Arrays/Declarations/BoolArrayInvalid may fail because of two reasons:

1. The intended test case of accessing an array with a subscript of the wrong type.
2. Due to the incorrect assignment of a boolean to a real value.

To ensure that the test actually covers the correct functionality change the assignment to real values