### PR TITLE
Fix incorrect comparison in ModelicaCompliance.Arrays.Declarations.ArrayTypeIntegerMatrix

### DIFF
--- a/ModelicaCompliance/Arrays/Declarations/ArrayTypeIntegerMatrix.mo
+++ b/ModelicaCompliance/Arrays/Declarations/ArrayTypeIntegerMatrix.mo
@@ -5,12 +5,12 @@ model ArrayTypeIntegerMatrix
 
   Integer x[2,3] = [ 1,2,3 ; 4,5,6 ] ;
 equation
-  assert(x[1, 1] == 1.0, "x[1, 1] was not set correctly.");
-  assert(x[1, 2] == 2.0, "x[1, 2] was not set correctly.");
-  assert(x[1, 3] == 3.0, "x[1, 3] was not set correctly.");
-  assert(x[2, 1] == 4.0, "x[2, 1] was not set correctly.");
-  assert(x[2, 2] == 5.0, "x[2, 2] was not set correctly.");
-  assert(x[2, 3] == 6.0, "x[2, 3] was not set correctly.");
+  assert(x[1, 1] == 1, "x[1, 1] was not set correctly.");
+  assert(x[1, 2] == 2, "x[1, 2] was not set correctly.");
+  assert(x[1, 3] == 3, "x[1, 3] was not set correctly.");
+  assert(x[2, 1] == 4, "x[2, 1] was not set correctly.");
+  assert(x[2, 2] == 5, "x[2, 2] was not set correctly.");
+  assert(x[2, 3] == 6, "x[2, 3] was not set correctly.");
 
   annotation (
     __ModelicaAssociation(TestCase(shouldPass = true, section = {"10.1"})),

--- a/ModelicaCompliance/Arrays/Declarations/ArrayTypeIntegerParameter.mo
+++ b/ModelicaCompliance/Arrays/Declarations/ArrayTypeIntegerParameter.mo
@@ -5,12 +5,12 @@ model ArrayTypeIntegerParameter
 
   parameter Integer x[2,3] = {{1, 2, 3}, {4, 5, 6}};
 equation
-  assert(x[1, 1] == 1.0, "x[1, 1] was not set correctly.");
-  assert(x[1, 2] == 2.0, "x[1, 2] was not set correctly.");
-  assert(x[1, 3] == 3.0, "x[1, 3] was not set correctly.");
-  assert(x[2, 1] == 4.0, "x[2, 1] was not set correctly.");
-  assert(x[2, 2] == 5.0, "x[2, 2] was not set correctly.");
-  assert(x[2, 3] == 6.0, "x[2, 3] was not set correctly.");
+  assert(x[1, 1] == 1, "x[1, 1] was not set correctly.");
+  assert(x[1, 2] == 2, "x[1, 2] was not set correctly.");
+  assert(x[1, 3] == 3, "x[1, 3] was not set correctly.");
+  assert(x[2, 1] == 4, "x[2, 1] was not set correctly.");
+  assert(x[2, 2] == 5, "x[2, 2] was not set correctly.");
+  assert(x[2, 3] == 6, "x[2, 3] was not set correctly.");
   
   annotation (
     __ModelicaAssociation(TestCase(shouldPass = true, section = {"10.1"})),


### PR DESCRIPTION
The modelica spec explicitely states in section 3.5 "Equality, Relational, and Logical Operators" bullet point 4:

```
In relations of the form v1 == v2 or v1 <> v2, v1 or v2 shall, unless used in a function, not be a subtype of
Real.
```

While assertions are more or less special and could be interpreted as functions, in this test there is no need, as the matrix  is an integer array anyway and we can simply compare with int.